### PR TITLE
Remove the broken link -> "Hits"

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
     <a href="https://www.jsdelivr.com/package/npm/color-calendar">
         <img src="https://data.jsdelivr.com/v1/package/npm/color-calendar/badge" alt="jsdelivr" />
     </a>
-    <img src="https://hitcounter.pythonanywhere.com/count/tag.svg?url=https%3A%2F%2Fgithub.com%2FPawanKolhe%2Fcolor-calendar" alt="Hits">
     <img src="https://img.shields.io/npm/l/color-calendar?style=flat-square" alt="license" />
 </p>
 


### PR DESCRIPTION
Hello, I have removed the broken link: "Hits" of the main page of the repository

![Screenshot from 2022-03-25 17-15-21](https://user-images.githubusercontent.com/60739184/160195278-aa1cea53-3b86-4fef-a796-047053df110d.png)
![Screenshot from 2022-03-25 17-15-31](https://user-images.githubusercontent.com/60739184/160195282-87b2eeef-be8e-4b81-90a2-37781e660721.png)
![Screenshot from 2022-03-25 17-15-35](https://user-images.githubusercontent.com/60739184/160195283-cb1339dc-1b52-4ef2-b519-9b7fd9b2aa76.png)
